### PR TITLE
Add Hypixel Server Brand

### DIFF
--- a/mappings/servers/hypixelnetwork/metadata.json
+++ b/mappings/servers/hypixelnetwork/metadata.json
@@ -2,6 +2,7 @@
     "id": "hypixelnetwork",
     "name": "Hypixel",
     "description": "The home of minigames",
+    "server_brand": "Hypixel BungeeCord \\(.+\\) <- .+",
     "addresses": [
         "hypixel.net"
     ],


### PR DESCRIPTION
Added the regex to identify the Hypixel Server Brand. This will be used for future server mapping handling.

This won't be a requirement unless a server has a unique brand identifier.